### PR TITLE
Add tracing propagation middleware

### DIFF
--- a/auth/internal/port/grpc/private/server.go
+++ b/auth/internal/port/grpc/private/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/parta4ok/kvs/auth/internal/entities"
 	"github.com/parta4ok/kvs/auth/internal/port"
 	"github.com/parta4ok/kvs/toolkit/pkg/tracing"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -365,7 +366,9 @@ func (srv *Server) setOptions(opts ...ServerOption) {
 
 func NewServer(opts ...ServerOption) (*Server, error) {
 	serv := &Server{
-		server:      grpc.NewServer(),
+		server: grpc.NewServer(
+			grpc.UnaryInterceptor(middleware.UnaryServerInterceptor()),
+		),
 		authService: &AuthService{},
 	}
 

--- a/auth/internal/port/http/public/server.go
+++ b/auth/internal/port/http/public/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/parta4ok/kvs/auth/pkg/dto"
 	"github.com/parta4ok/kvs/toolkit/pkg/accessor"
 	"github.com/parta4ok/kvs/toolkit/pkg/tracing"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -151,7 +152,10 @@ func (s *Server) Type() string {
 }
 
 func (s *Server) registerRoutes() {
-	s.router.Use(s.timeoutMiddleware)
+	s.router.Use(
+		middleware.TracingMiddleware,
+		s.timeoutMiddleware,
+	)
 
 	s.router.Post(basePath+signinPath, s.Signin)
 	s.router.Put(basePath+addUserPath, s.AddUser)

--- a/deployment/auth.yaml
+++ b/deployment/auth.yaml
@@ -26,7 +26,7 @@ jwt:
 tracing:
     system: otel
     servicename: auth
-    enabled: false
+    enabled: true
 otel:
     endpoint: jaeger:4317
     insecure: true

--- a/deployment/notificationhub.yaml
+++ b/deployment/notificationhub.yaml
@@ -20,7 +20,7 @@ nats:
 tracing:
     system: otel
     servicename: notificationhub
-    enabled: false
+    enabled: true
 otel:
     endpoint: jaeger:4317
     insecure: true

--- a/deployment/question.yaml
+++ b/deployment/question.yaml
@@ -34,7 +34,7 @@ nats:
 tracing:
     system: otel
     servicename: question
-    enabled: false
+    enabled: true
 otel:
     endpoint: jaeger:4317
     insecure: true

--- a/notificationhub/internal/port/nats/consumer.go
+++ b/notificationhub/internal/port/nats/consumer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/parta4ok/kvs/notificationhub/internal/entities"
 	port "github.com/parta4ok/kvs/notificationhub/internal/port"
 	natsDTO "github.com/parta4ok/kvs/toolkit/pkg/broker/nats"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -196,6 +197,7 @@ func (c *NatsConsumer) handleMessage(msg *nats.Msg) {
 
 func (c *NatsConsumer) processEvent(msg *nats.Msg) error {
 	slog.Info("processEvent", slog.String("subject", msg.Subject))
+	ctx := middleware.ExtractTraceFromNatsMessage(c.ctx, msg)
 
 	var reportEventDTO natsDTO.ReportEventDTO
 	if err := json.Unmarshal(msg.Data, &reportEventDTO); err != nil {
@@ -227,7 +229,7 @@ func (c *NatsConsumer) processEvent(msg *nats.Msg) error {
 		slog.Error("new normal event", "error", err)
 	}
 
-	if err := c.service.SendMessage(c.ctx, event); err != nil {
+	if err := c.service.SendMessage(ctx, event); err != nil {
 		slog.Error("send message", "error", err)
 	}
 

--- a/question/internal/port/http/private/server.go
+++ b/question/internal/port/http/private/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/parta4ok/kvs/question/internal/entities"
 	"github.com/parta4ok/kvs/question/pkg/dto"
 	"github.com/parta4ok/kvs/toolkit/pkg/tracing"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -128,6 +129,7 @@ func (s *Server) Type() string {
 
 func (s *Server) registerRoutes() {
 	s.router.Use(
+		middleware.TracingMiddleware,
 		s.timeoutMiddleware,
 	)
 

--- a/question/internal/port/http/public/server.go
+++ b/question/internal/port/http/public/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/parta4ok/kvs/question/pkg/dto"
 	"github.com/parta4ok/kvs/toolkit/pkg/accessor"
 	"github.com/parta4ok/kvs/toolkit/pkg/tracing"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -177,6 +178,7 @@ func (s *Server) Type() string {
 
 func (s *Server) registerRoutes() {
 	s.router.Use(
+		middleware.TracingMiddleware,
 		s.timeoutMiddleware,
 		s.introspectMiddleware,
 	)

--- a/reporting/internal/port/http/public/server.go
+++ b/reporting/internal/port/http/public/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/parta4ok/kvs/reporting/pkg/dto"
 	"github.com/parta4ok/kvs/toolkit/pkg/accessor"
 	"github.com/parta4ok/kvs/toolkit/pkg/tracing"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -159,6 +160,7 @@ func (s *Server) Type() string {
 
 func (s *Server) registerRoutes() {
 	s.router.Use(
+		middleware.TracingMiddleware,
 		s.timeoutMiddleware,
 		s.introspectMiddleware,
 	)

--- a/reporting/internal/port/nats/consumer.go
+++ b/reporting/internal/port/nats/consumer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/parta4ok/kvs/reporting/internal/entities"
 	port "github.com/parta4ok/kvs/reporting/internal/port"
 	natsDTO "github.com/parta4ok/kvs/toolkit/pkg/broker/nats"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -192,7 +193,8 @@ func (c *NatsConsumer) processEvent(msg *nats.Msg) error {
 			return errors.Wrap(entities.ErrInternal, "failed to cast session event")
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx := middleware.ExtractTraceFromNatsMessage(context.Background(), msg)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 
 		if err := c.service.DeliverySessionResult(ctx, &entities.SessionResult{

--- a/toolkit/pkg/auth/client/client.go
+++ b/toolkit/pkg/auth/client/client.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	authv1 "github.com/parta4ok/kvs/api/grpc/v1"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 )
 
 type AuthClient struct {
@@ -19,6 +20,7 @@ func New(addr string, opts ...grpc.DialOption) (*AuthClient, error) {
 	if len(opts) == 0 {
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithUnaryInterceptor(middleware.UnaryClientInterceptor()),
 		}
 	}
 

--- a/toolkit/pkg/broker/nats/publisher/pub.go
+++ b/toolkit/pkg/broker/nats/publisher/pub.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/nats-io/nats.go"
+	"github.com/parta4ok/kvs/toolkit/pkg/tracing/middleware"
 	"github.com/pkg/errors"
 )
 
@@ -50,11 +51,14 @@ func (publisher *Publisher) Publish(ctx context.Context, subject string, message
 	}
 
 	slog.Info("About to publish message via JetStream")
-	ack, err := publisher.conn.PublishMsg(&nats.Msg{
+	msg := &nats.Msg{
 		Subject: subject,
 		Data:    message,
-	}, nats.Context(ctx))
+	}
 
+	middleware.InjectTraceToNatsMessage(ctx, msg)
+
+	ack, err := publisher.conn.PublishMsg(msg, nats.Context(ctx))
 	if err != nil {
 		slog.Error("JetStream publish failed", slog.String("error", err.Error()))
 		return errors.Wrapf(ErrInternal, "failed to publish message: %v", err)

--- a/toolkit/pkg/question/client/client.go
+++ b/toolkit/pkg/question/client/client.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 const (
@@ -79,6 +81,8 @@ func (client *Client) GetPassedStudentsTopics(ctx context.Context, students []st
 	slog.Info("request data", slog.String("method", req.Method), slog.String("url", req.URL.String()))
 	req.Header.Set("Content-Type", "application/json")
 
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+	
 	resp, err := client.c.Do(req)
 	if err != nil {
 		slog.Error("client.do failure", "error", err)
@@ -108,7 +112,6 @@ func (client *Client) processErr(statusCode int) error {
 	switch statusCode { //nolint:gocritic // will be extension on the next steps
 	case http.StatusBadRequest:
 		return ErrBadRequest
-
 	}
 	return ErrInternal
 }

--- a/toolkit/pkg/tracing/middleware/grpc.go
+++ b/toolkit/pkg/tracing/middleware/grpc.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		md = md.Copy()
+		otel.GetTextMapPropagator().Inject(ctx, metadataCarrier{md})
+		ctx = metadata.NewOutgoingContext(ctx, md)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler) (any, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			ctx = otel.GetTextMapPropagator().Extract(ctx, metadataCarrier{md})
+		}
+		return handler(ctx, req)
+	}
+}
+
+type metadataCarrier struct {
+	md metadata.MD
+}
+
+func (c metadataCarrier) Get(key string) string {
+	values := c.md.Get(key)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (c metadataCarrier) Set(key, value string) {
+	c.md.Set(key, value)
+}
+
+func (c metadataCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.md))
+	for k := range c.md {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/toolkit/pkg/tracing/middleware/http.go
+++ b/toolkit/pkg/tracing/middleware/http.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+func TracingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		ctx := otel.GetTextMapPropagator().Extract(
+			req.Context(),
+			propagation.HeaderCarrier(req.Header),
+		)
+		req = req.WithContext(ctx)
+		next.ServeHTTP(resp, req)
+	})
+}

--- a/toolkit/pkg/tracing/middleware/nats.go
+++ b/toolkit/pkg/tracing/middleware/nats.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+)
+
+func InjectTraceToNatsMessage(ctx context.Context, msg *nats.Msg) {
+	if msg.Header == nil {
+		msg.Header = nats.Header{}
+	}
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier{msg.Header})
+}
+
+func ExtractTraceFromNatsMessage(ctx context.Context, msg *nats.Msg) context.Context {
+	if msg.Header == nil {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier{msg.Header})
+}
+
+type natsHeaderCarrier struct {
+	header nats.Header
+}
+
+func (c natsHeaderCarrier) Get(key string) string {
+	values := c.header.Values(key)
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (c natsHeaderCarrier) Set(key, value string) {
+	c.header.Set(key, value)
+}
+
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.header))
+	for k := range c.header {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
Wire HTTP, gRPC and NATS propagation: add middleware, inject/extract trace context in clients, servers, publishers and consumers. Enable tracing in deployment configs.